### PR TITLE
Bestbuy cart 5.6

### DIFF
--- a/bestbuy-cart/script_main.js
+++ b/bestbuy-cart/script_main.js
@@ -236,7 +236,7 @@ async function resetSaved(skipUnload, fromCart) {
 
     // Setup auto page refresh, not sure if zero value does anything
     // Perform first to reduce chances of not working when tab not focused
-    if(settings.autoReloadInterval.value > 10000) {
+    if(settings.autoReloadInterval.value >= 10000) {
         setTimeout(function() {
             window.location.reload();
         }, settings.autoReloadInterval.value);


### PR DESCRIPTION
- Removed adblock checking functionality until fixed
- Added keyword blacklist and whitelist settings input as string (array input on the way, somehow)
- Changed audio to only play when items are added to cart, should now trigger when items are added to cart without queue
- Fixed color interval leak (forgot to change reset functionality when changing from per-product to single interval)